### PR TITLE
add UV::walk() and sync call ver UV::handles()

### DIFF
--- a/src/UV.xs
+++ b/src/UV.xs
@@ -16,6 +16,21 @@
 #define UV_CONST_GEN(uc, lc) \
     newCONSTSUB(stash, #uc, newSViv(UV_##uc));
 
+/* copy from libuv/src/uv-common.h */
+#ifndef _WIN32
+enum {
+  UV__HANDLE_INTERNAL = 0x8000,
+  UV__HANDLE_ACTIVE   = 0x4000,
+  UV__HANDLE_REF      = 0x2000,
+  UV__HANDLE_CLOSING  = 0 /* no-op on unix */
+};
+#else
+# define UV__HANDLE_INTERNAL  0x80
+# define UV__HANDLE_ACTIVE    0x40
+# define UV__HANDLE_REF       0x20
+# define UV__HANDLE_CLOSING   0x01
+#endif
+
 typedef struct {
     SV* connection_cb;
     SV* connect_cb;
@@ -685,6 +700,40 @@ CODE:
 {
     /* what's the proper way to return a int64_t? */
     RETVAL = (NV) uv_now(uv_default_loop());
+}
+OUTPUT:
+    RETVAL
+
+AV*
+uv_handles()
+CODE:
+{
+    ngx_queue_t* q;
+    ngx_queue_t* queue;
+    uv_loop_t* loop;
+    uv_handle_t* h;
+    HV* hv;
+    AV* av;
+
+    av = (AV*)sv_2mortal((SV*)newAV());
+    loop = uv_default_loop();
+    queue = &loop->handle_queue;
+
+    ngx_queue_foreach(q, queue) {
+        h = ngx_queue_data(q, uv_handle_t, handle_queue);
+        if (h->flags & UV__HANDLE_INTERNAL) continue; /* check internal bit */
+
+        hv = newHV();
+
+        hv_store(hv, "type", 4, newSViv(h->type), 0); /* type */
+        hv_store(hv, "active", 6, newSViv((h->flags & UV__HANDLE_ACTIVE) ? 1 : 0), 0);
+        hv_store(hv, "ref", 3, newSViv((h->flags & UV__HANDLE_REF) ? 1 : 0), 0);
+        hv_store(hv, "closing", 7, newSViv((h->flags & UV__HANDLE_CLOSING) ? 1 : 0), 0);
+
+        av_push(av, newRV_inc((SV*)hv));
+    }
+
+    RETVAL = av;
 }
 OUTPUT:
     RETVAL

--- a/t/handles.t
+++ b/t/handles.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+use Test::More;
+
+use UV;
+
+{
+    my $handles = [];
+
+    my $t1 = UV::timer_init();
+    UV::timer_start($t1, 100, 0, sub {
+        # do nothing
+        UV::close($t1);
+    });
+    my $t2 = UV::timer_init();
+    UV::timer_start($t2, 150, 0, sub {
+        # do nothing
+        UV::close($t2);
+    });
+
+    my $count_timer = UV::timer_init();
+    UV::timer_start($count_timer, 60, 100, sub {
+        push @$handles, UV::handles();
+    });
+
+    my $timeout_timer = UV::timer_init();
+    UV::timer_start($timeout_timer, 200, 0, sub {
+        UV::close($count_timer);
+    });
+
+    UV::run();
+
+    is scalar(@{$handles}), 2;
+    is scalar(@{$handles->[0]}), 4;
+    is_deeply $handles->[0]->[0], { ref => 1, active => 1, type => UV::TIMER(), closing => 0 };
+    is scalar(@{$handles->[1]}), 2;
+    is_deeply $handles->[1]->[1], { ref => 1, active => 1, type => UV::TIMER(), closing => 0 };
+}
+
+done_testing;

--- a/t/walk.t
+++ b/t/walk.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+use Test::More;
+
+use UV;
+
+{
+    my $counts1 = 0;
+    my $counts2 = 0;
+
+    my $t1 = UV::timer_init();
+    UV::timer_start($t1, 100, 0, sub {
+        # do nothing
+        UV::close($t1);
+    });
+    my $t2 = UV::timer_init();
+    UV::timer_start($t2, 150, 0, sub {
+        # do nothing
+        UV::close($t2);
+    });
+
+    use Data::Dumper;
+
+    my $count_timer1 = UV::timer_init();
+    UV::timer_start($count_timer1, 60, 0, sub {
+        UV::walk(sub{ $counts1 += 1; });
+        UV::close($count_timer1);
+    });
+    my $count_timer2 = UV::timer_init();
+    UV::timer_start($count_timer2, 120, 0, sub {
+        UV::walk(sub{ $counts2 += 1; });
+        UV::close($count_timer2);
+    });
+
+    UV::run();
+
+    is $counts1, 4; # t1, t2, count_timer1, count_timer2
+    is $counts2, 2; # t2, count_timer2
+}
+
+done_testing;


### PR DESCRIPTION
Add methods
- UV::walk() to support uv_walk()
- UV::handles() to get informations list of all handles as sync call

UV::handles() helps to search non-closed handlers in troubles.
