### PR TITLE
Fix t/version.t for version parts with a value greater than 15

### DIFF
--- a/t/version.t
+++ b/t/version.t
@@ -7,9 +7,9 @@ use UV;
 my $version     = UV::version;
 my $version_str = UV::version_string;
 
-my $major = $version >> 16 & 0xf;
-my $minor = $version >> 8 & 0xf;
-my $patch = $version & 0xf;
+my $major = $version >> 16 & 0xff;
+my $minor = $version >> 8 & 0xff;
+my $patch = $version & 0xff;
 
 my ($v1, $v2, $v3) = split /\./, $version_str;
 


### PR DESCRIPTION
e.g. enable 0.10.16 to work not just 0.10.15 and lower.  I noticed this trying out the latest stable libuv version 0.10.27.
